### PR TITLE
Basic R parallelization of cv.ncvreg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,4 +7,4 @@ Maintainer: Patrick Breheny <patrick-breheny@uiowa.edu>
 Description: Efficient algorithms for fitting regularization paths for linear or logistic regression models penalized by MCP or SCAD, with optional additional L2 penalty ("Mnet").
 License: GPL-2
 URL: http://myweb.uiowa.edu/pbreheny/publications/Breheny2011.pdf
-Depends: 
+Depends:parallel 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,5 @@
 useDynLib(ncvreg,.registration=TRUE)
-export(ncvreg, cv.ncvreg, ncvreg_fit, fir, perm.ncvreg, setupLambda)
+export(ncvreg, cv.ncvreg, pa.cv.ncvreg, ncvreg_fit, fir, perm.ncvreg, setupLambda)
 S3method(summary,cv.ncvreg)
 S3method(print,summary.cv.ncvreg)
 importFrom(graphics,plot)

--- a/R/pa.cv.ncvreg.R
+++ b/R/pa.cv.ncvreg.R
@@ -1,0 +1,72 @@
+pa.cv.ncvreg <- function(cl, X, y, ..., nfolds=10, seed, trace=FALSE) {
+  if (!missing(seed)) set.seed(seed)
+  cv.ind = NA
+  fit <- ncvreg(X=X, y=y, ...)
+  n <- length(y)
+  E <- matrix(NA, nrow=n, ncol=length(fit$lambda))
+  if (fit$family=="binomial") {
+    if (min(table(y)) < nfolds) stop("nfolds is larger than the smaller of 0/1 in the data; decrease nfolds")
+    PE <- E
+  }
+  
+  if (fit$family=="binomial") {
+    ind1 <- which(y==1)
+    ind0 <- which(y==0)
+    n1 <- length(ind1)
+    n0 <- length(ind0)
+    cv.ind1 <- ceiling(sample(1:n1)/n1*nfolds)
+    cv.ind0 <- ceiling(sample(1:n0)/n0*nfolds)
+    cv.ind <- numeric(n)
+    cv.ind[y==1] <- cv.ind1
+    cv.ind[y==0] <- cv.ind0
+  } else {
+    cv.ind <- ceiling(sample(1:n)/n*nfolds)
+  }
+  cv.args.parent <- list(...)
+  if (!missing(seed)) cv.args.parent[["seed"]] = seed 
+  clusterExport(cl, c("cv.ind","fit","X", "y","cv.args.parent"),
+                envir=environment())
+  fold.func <- function(i){
+    library(ncvreg)
+    if (length(cv.args.parent[["seed"]] != 0)){
+        set.seed(cv.args.parent[["seed"]] + i)
+    }
+    cv.args <- cv.args.parent 
+    cv.args$X <- X[cv.ind!=i, , drop=FALSE]
+    cv.args$y <- y[cv.ind!=i]
+    cv.args$lambda <- fit$lambda
+    cv.args$warn <- FALSE
+    fit.i = do.call("ncvreg", cv.args)
+    X2 <- X[cv.ind==i, , drop=FALSE]
+    y2 <- y[cv.ind==i]
+    yhat <- predict(fit.i, X2, type="response")
+    loss = loss.ncvreg(y2, yhat, fit$family)
+    list(yhat=yhat, loss=loss, y2=y2, binom.loss = ((yhat < 0.5) == y2))
+  }
+
+  fold.results = parLapply(cl, 1:nfolds, fold.func)
+
+  for (i in 1:nfolds) {
+    if (trace) cat("Processing CV fold #",i,sep="","\n") 
+    res <- fold.results[[i]]
+    E[cv.ind==i, 1:ncol(res$yhat)] <- res$loss
+    if (fit$family=="binomial") PE[cv.ind==i, 1:ncol(res$yhat)] <- res$binom.loss
+  }
+  
+  ## Eliminate saturated lambda values, if any
+  ind <- which(apply(is.finite(E), 2, all))
+  E <- E[,ind]
+  lambda <- fit$lambda
+
+  ## Return
+  cve <- apply(E, 2, mean)
+  cvse <- apply(E, 2, sd) / sqrt(n)
+  min <- which.min(cve)
+  
+  val <- list(cve=cve, cvse=cvse, lambda=lambda, fit=fit, min=min, lambda.min=lambda[min], null.dev=mean(loss.ncvreg(y, rep(mean(y), n), fit$family)))
+  if (fit$family=="binomial") {
+    pe <- apply(PE, 2, mean)
+    val$pe <- pe[is.finite(pe)]
+  }
+  structure(val, class="cv.ncvreg")
+}

--- a/man/pa.cv.ncvreg.Rd
+++ b/man/pa.cv.ncvreg.Rd
@@ -1,0 +1,67 @@
+\name{pa.cv.ncvreg}
+\alias{pa.cv.ncvreg}
+\title{Cross-validation for ncvreg}
+\description{Performs k-fold cross validation for MCP- or SCAD-penalized
+  regression models over a grid of values for the regularization
+  parameter lambda in parallel using clusters created by the R \code{parallel} 
+  package. Otherwise identical to \code{cv.ncvreg}.}
+\usage{
+pa.cv.ncvreg(cl, X, y, ..., nfolds=10, seed, trace=FALSE)
+}
+\arguments{
+  \item{cl}{A cluster object created with \code{makeCluster}.}
+  \item{X}{The design matrix, without an intercept, as in
+    \code{ncvreg}.}
+  \item{y}{The response vector, as in \code{ncvreg}.}
+  \item{...}{Additional arguments to \code{ncvreg}.}
+  \item{nfolds}{The number of cross-validation folds.  Default is 10.}
+  \item{seed}{You may set the seed of the random number generator in
+    order to obtain reproducible results.}
+  \item{trace}{If set to TRUE, pa.cv.ncvreg will provide 
+    an indication of progress in processing CV folds. Due to the
+    parallelized execution of each fold, however, behavior equivalent
+    to \code{trace=TRUE} in \code{cv.ncvreg} is not available. Default is
+    FALSE.}
+  }
+\details{
+  The function calls \code{ncvreg} \code{nfolds} times, each time
+  leaving out 1/\code{nfolds} of the data.  The cross-validation
+  error is based on the residual sum of squares when
+  \code{family="gaussian"} and the binomial deviance when
+  \code{family="binomial"}.}
+\value{
+  An object with S3 class \code{"cv.ncvreg"} containing:
+  \item{cve}{The error for each value of \code{lambda}, averaged
+    across the cross-validation folds.}
+  \item{cvse}{The estimated standard error associated with each value of
+    for \code{cve}.}
+  \item{lambda}{The sequence of regularization parameter values along
+    which the cross-validation error was calculated.}
+  \item{fit}{The fitted \code{ncvreg} object for the whole data.}
+  \item{min}{The index of \code{lambda} corresponding to
+    \code{lambda.min}.}
+  \item{lambda.min}{The value of \code{lambda} with the minimum
+    cross-validation error.}
+  \item{null.dev}{The deviance for the intercept-only model.}
+  \item{pe}{If \code{family="binomial"}, the cross-validation prediction
+    error for each value of \code{lambda}.}
+  }
+\references{Breheny, P. and Huang, J. (2011) Coordinate descent
+  algorithms for nonconvex penalized regression, with applications to
+  biological feature selection. Ann. Appl. Statist., 5: 232-253.}
+\author{Patrick Breheny <patrick-breheny@uiowa.edu>}
+\seealso{\code{ncvreg}, \code{cv.ncvreg}, \code{plot.cv.ncvreg}, \code{summary.cv.ncvreg}}
+\examples{
+data(prostate)
+X <- as.matrix(prostate[,1:8])
+y <- prostate$lpsa
+cl=makeCluster(3)
+cvfit <- pa.cv.ncvreg(cl,X,y)
+stopCluster(cl)
+plot(cvfit)
+summary(cvfit)
+
+fit <- cvfit$fit
+plot(fit)
+beta <- fit$beta[,cvfit$min]
+}


### PR DESCRIPTION
Adds a function "pa.cv.ncvreg" and associated documentation which allows cross validation calls to ncvreg to be made and executed in parallel. Adds library dependency "parallel", which is included in versions of R >= 2.14. 

Example usage and timings are available [here](https://gist.github.com/grantbrown/a8cbd3c77a3d6ee9e2c1)