### PR TITLE
Changed max.iter to 5000 for better chance of convergence

### DIFF
--- a/R/ncvreg.R
+++ b/R/ncvreg.R
@@ -1,6 +1,6 @@
 ncvreg <- function(X, y, family=c("gaussian","binomial","poisson"), penalty=c("MCP", "SCAD", "lasso"),
                    gamma=switch(penalty, SCAD=3.7, 3), alpha=1, lambda.min=ifelse(n>p,.001,.05), nlambda=100,
-                   lambda, eps=1e-4, max.iter=1000, convex=TRUE, dfmax=p+1, penalty.factor=rep(1, ncol(X)),
+                   lambda, eps=1e-4, max.iter=5000, convex=TRUE, dfmax=p+1, penalty.factor=rep(1, ncol(X)),
                    warn=TRUE, returnX=FALSE, ...) {
   # Coersion
   family <- match.arg(family)

--- a/R/ncvsurv.R
+++ b/R/ncvsurv.R
@@ -1,5 +1,5 @@
 ncvsurv <- function(X, y, penalty=c("MCP", "SCAD", "lasso"), gamma=switch(penalty, SCAD=3.7, 3),
-                    alpha=1, lambda.min=ifelse(n>p,.001,.05), nlambda=100, lambda, eps=1e-4, max.iter=1000,
+                    alpha=1, lambda.min=ifelse(n>p,.001,.05), nlambda=100, lambda, eps=1e-4, max.iter=5000,
                     convex=TRUE, dfmax=p, penalty.factor=rep(1, ncol(X)), warn=TRUE, returnX=FALSE, ...) {
 
   # Coersion

--- a/man/ncvreg.Rd
+++ b/man/ncvreg.Rd
@@ -9,7 +9,7 @@
 ncvreg(X, y, family=c("gaussian", "binomial", "poisson"),
 penalty=c("MCP", "SCAD", "lasso"), gamma=switch(penalty, SCAD=3.7, 3),
 alpha=1, lambda.min=ifelse(n>p,.001,.05), nlambda=100, lambda, eps=1e-4,
-max.iter=1000, convex=TRUE, dfmax=p+1, penalty.factor=rep(1, ncol(X)),
+max.iter=5000, convex=TRUE, dfmax=p+1, penalty.factor=rep(1, ncol(X)),
 warn=TRUE, returnX=FALSE, ...)
 }
 \arguments{
@@ -38,7 +38,7 @@ warn=TRUE, returnX=FALSE, ...)
   \item{eps}{Convergence threshhold.  The algorithm iterates until the
     RMSD for the change in linear predictors for any coefficient is less
     than \code{eps}.  Default is \code{1e-4}.}
-  \item{max.iter}{Maximum number of iterations.  Default is 1000.}
+  \item{max.iter}{Maximum number of iterations.  Default is 5000.}
   \item{convex}{Calculate index for which objective function ceases to
     be locally convex?  Default is TRUE.}
   \item{dfmax}{Upper bound for the number of nonzero coefficients.

--- a/man/ncvsurv.Rd
+++ b/man/ncvsurv.Rd
@@ -8,7 +8,7 @@
 ncvsurv(X, y, penalty=c("MCP", "SCAD", "lasso"),
 gamma=switch(penalty, SCAD=3.7, 3), alpha=1,
 lambda.min=ifelse(n>p,.001,.05), nlambda=100, lambda, eps=1e-4,
-max.iter=1000, convex=TRUE, dfmax=p, penalty.factor=rep(1, ncol(X)),
+max.iter=5000, convex=TRUE, dfmax=p, penalty.factor=rep(1, ncol(X)),
 warn=TRUE, returnX=FALSE, ...)
 }
 \arguments{
@@ -39,7 +39,7 @@ warn=TRUE, returnX=FALSE, ...)
   \item{eps}{Convergence threshhold.  The algorithm iterates until the
     RMSD for the change in linear predictors for any coefficient is less
     than \code{eps}.  Default is \code{1e-4}.}
-  \item{max.iter}{Maximum number of iterations.  Default is 1000.x}
+  \item{max.iter}{Maximum number of iterations.  Default is 5000.}
   \item{convex}{Calculate index for which objective function ceases to
     be locally convex?  Default is TRUE.}
   \item{dfmax}{Upper bound for the number of nonzero coefficients.


### PR DESCRIPTION
In some cases, `ncvsurv()` could be "harder" to converge under the new RMSD criterion.

For example:

```r
library("ncvreg")
library("hdnom")
library("survival")

# first 150 obs
data("smart")
x = as.matrix(smart[, -c(1, 2)])[1:150, ]
time = smart$TEVENT[1:150]
event = smart$EVENT[1:150]
y = Surv(time, event)

fit = ncvsurv(x, y, penalty = "MCP", alpha = 1, gamma = 2)
fit = ncvsurv(x, y, penalty = "MCP", alpha = 1, gamma = 2, max.iter = 5000)
fit = ncvsurv(x, y, penalty = "SCAD", alpha = 1, gamma = 3.7)
fit = ncvsurv(x, y, penalty = "SCAD", alpha = 1, gamma = 3.7, max.iter = 5000)
```

The 1st and 3rd fit used to converge under the old criterion.

This PR increased the default value of `max.iter` from 1000 to 5000, which could give a better chance for convergence under the new criterion. Since the iterations here are really fast, this change will not likely to have a significant performance impact.