### PR TITLE
Create Makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,1 @@
+PKG_CFLAGS += -std=c99


### PR DESCRIPTION
This solves the error when I try to install ncvreg:

    error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode

See here for an explanation about the error:

http://stackoverflow.com/questions/24881

Here is my full error:

```
R CMD INSTALL .
* installing to library ‘/PHShome/ks38/.local/lib/R/x86_64-linux-gnu-library/3.4’
* installing *source* package ‘ncvreg’ ...
** libs
gcc -I/apps/lib-osver/R/3.4.0/lib64/R/include -DNDEBUG   -I/apps/lib-osver/gcc/6.3.0//include -L/apps/lib-osver/gcc/6.3.0/lib64 -L/apps/lib-osver/gcc/6.3.0/lib6:-I/source/zlib/1.2.8/include: -I/source/zlib/1.2.8/include -L/source/zlib/1.2
.8/lib -I/source/bzip2/1.0.6/include -L/source/bzip2/1.0.6/lib -I/source/lzma/5.0.7/include -L/source/lzma/5.0.7/lib -I//apps/lib-osver/pcre/8.38/include -L/apps/lib-osver/pcre/8.38/lib -I/source/libcurl/7.35.0/include -I/source/libcurl/7
.35.0/lib    -fpic  -I/apps/lib-osver/gcc/6.3.0//include -L/apps/lib-osver/gcc/6.3.0/lib64 -L/apps/lib-osver/gcc/6.3.0/lib6:-I/source/zlib/1.2.8/include: -I/source/zlib/1.2.8/include -L/source/zlib/1.2.8/lib -I/source/bzip2/1.0.6/include
-L/source/bzip2/1.0.6/lib -I/source/lzma/5.0.7/include -L/source/lzma/5.0.7/lib -I//apps/lib-osver/pcre/8.38/include -L/apps/lib-osver/pcre/8.38/lib -I/source/libcurl/7.35.0/include -I/source/libcurl/7.35.0/lib   -c binomial.c -o binomial
.o
binomial.c: In function ‘cdfit_binomial’:
binomial.c:58:3: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
   for (int i=0; i<L; i++) b0[i] = 0;
   ^
binomial.c:58:3: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
```